### PR TITLE
FIX: rebloquear ramos cuando se desmarca prerrequisito

### DIFF
--- a/data/ramos.json
+++ b/data/ramos.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "01",
-    "nombre": "Computación para Ingeniería",
+    "nombre": "Computación para la Ingeniería",
     "prereqs": [],
     "semestre": 1,
     "area": "Formación Específica"

--- a/js/app.js
+++ b/js/app.js
@@ -54,11 +54,12 @@ function renderMalla() {
       div.id = ramo.id;
 
       const prereqsListos = ramo.prereqs.every((id) => estado[id]);
-
-      if (estado[ramo.id]) {
-        div.classList.add('tachado');
-      } else if (!prereqsListos) {
+      // FIX: Si no cumple el prerequisito, se bloquea y limpiamos estado
+      if(!prereqsListos){
         div.classList.add('bloqueado');
+        estado[ramo.id] = false; // Fuerza que no esté aprobado
+      } else if (estado[ramo.id]) {
+        div.classList.add('tachado');
       }
 
       div.addEventListener('click', () => {
@@ -74,9 +75,9 @@ function renderMalla() {
 
       columna.appendChild(div);
     });
-
     container.appendChild(columna);
   }
+  localStorage.setItem('estadoRamos', JSON.stringify(estado)); // Se guarda el estado corregido (FIX)
 }
 
 function eliminarTildes(texto){


### PR DESCRIPTION
Fix con la lógica de prerrequisitos en la malla curricular interactiva.

Cambios realizados:
- Se valida dinámicamente que todos los prerrequisitos estén marcados como completados antes de permitir aprobar un ramo.
- Si un prerrequisito es desmarcado, los ramos que dependían de él ahora se rebloquean automáticamente.
- El nuevo estado corregido se guarda en localStorage.
